### PR TITLE
Everything reaches main through a pull request now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,27 +5,28 @@ name: tests
 # remembers. There are no dependencies, so there is nothing to install and
 # nothing to cache — `node --test` is the whole job.
 
-# Not on notes-only commits. Every job below asks a question about SHIPPED
-# BYTES -- the suite, the browser, the redirect behaviour, the precache list,
-# the About dateline -- and a commit that touches nothing but `notes/` cannot
-# change any of their answers. 240 of the first 330 commits on main were
-# exactly that, and because GitHub rounds every job up to a whole minute, they
-# cost six billed minutes each and bought nothing. A commit touching `notes/`
-# AND anything else still runs everything: paths-ignore skips only when EVERY
-# changed path matches.
+# EVERY PUSH AND EVERY PR, WITH NO PATH FILTER. It used to skip notes-only
+# commits: 240 of the first 330 commits on main touched nothing but `notes/`,
+# GitHub rounds every job up to a whole minute, and those commits cost six
+# billed minutes each to answer a question about shipped bytes that they could
+# not change. That filter was correct then and is wrong now, for two reasons
+# that arrived together.
 #
-# Safe because no check here is required by branch protection -- there is none,
-# by an explicit decision. If that ever changes, a skipped required check
-# blocks PRs forever, and this filter has to go or become `paths` on the code.
+#   1. THESE CHECKS ARE REQUIRED NOW. Work moves through pull requests, and a
+#      required check that never runs leaves a PR pending forever rather than
+#      failing it. A notes-only PR would have hung on a job that was never
+#      going to report. `test.yml` used to say this filter had to go the day
+#      that changed; this is that day.
+#   2. The minutes are free. Public repositories do not consume the Actions
+#      allowance, so the saving the filter bought no longer exists.
+#
+# Do not put a path filter back on a required check. If the cost ever matters
+# again, make the job report a deliberate skip instead of not reporting.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'notes/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'notes/**'
   workflow_dispatch:
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,11 @@ is the order of operations for the parts a harness does not cover.
 which is honest rather than decorative: those checks are written down and
 nothing here can decide them.
 
-**Review** against `REVIEW.md` before committing — same passes every time, and
-severity that means the same thing twice running.
+**Review** against `REVIEW.md`, on a pull request. Every change reaches `main`
+through one — no exceptions, including a one-line fix and including a change
+that touches only `notes/`. Branch, commit, push, open the PR, and let the
+checks report before merging. The same passes every time, and severity that
+means the same thing twice running.
 
 ## What is enforced, and what is only written down
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -4,9 +4,21 @@ The review policy, so that every change gets the same passes and severity means
 the same thing twice running. `AGENTS.md` is the harness and says *why* each
 rule below exists; this file says only what a review does with it.
 
-Read by `/code-review`, and ready for `claude-code-action` if work ever moves
-onto pull requests. It does not today: 382 commits, no PRs, and no branch
-protection by an explicit decision recorded in `.github/workflows/test.yml`.
+Read by `/code-review`, and applied to every pull request. **Nothing reaches
+`main` except through one.** That is a change from how this repo ran for its
+first 384 commits, which went straight to `main` by an explicit decision; the
+reasoning that decision rested on -- no second pair of eyes to wait for, and
+billed CI minutes -- stopped holding when the work started needing a review
+gate more than it needed speed.
+
+Two consequences worth stating, because both have teeth:
+
+- **No path filter may be added to a required check.** A required check that
+  does not run leaves a PR pending forever rather than failing it, so a
+  notes-only PR would hang on a job that was never going to report.
+  `test/ci-config.test.js` fails if one comes back.
+- **An agent may not approve its own work.** It can open the PR, address
+  comments and push fixes; the approval is a human's.
 
 ## Passes, in order
 

--- a/test/ci-config.test.js
+++ b/test/ci-config.test.js
@@ -1,0 +1,81 @@
+/* Branch protection is configured in GitHub's UI, not in this repo, which
+ * means the two can drift and nothing in the tree would notice. These are the
+ * assertions that catch the drift from this side.
+ *
+ * Two failure modes, and both are silent, which is why they are pinned rather
+ * than trusted:
+ *
+ *   1. A PATH FILTER ON A REQUIRED CHECK. A required check that does not run
+ *      does not fail the pull request -- it leaves it pending, forever, with
+ *      no error to read. `test.yml` carried `paths-ignore: notes/**` for its
+ *      whole life and it was correct while nothing was required; the day the
+ *      checks became required it turned into a trap where a notes-only PR
+ *      hangs on a job that was never going to report. Re-adding one would not
+ *      break any test that existed before this file.
+ *
+ *   2. A RENAMED JOB. GitHub requires checks BY NAME. Rename `smoke (390×844)`
+ *      and branch protection keeps waiting for a check nothing will ever
+ *      produce, while the renamed job runs and goes green beside it. The
+ *      branch is then unprotected and every signal says it is fine.
+ *
+ * `vendor-drift.yml` is deliberately exempt: it is scheduled, conditional on a
+ * PR label, and is NOT a required check. Its path filter is correct and must
+ * stay.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const ROOT = new URL('../', import.meta.url);
+const read = f => readFileSync(new URL(f, ROOT), 'utf8');
+
+const tests = read('.github/workflows/test.yml');
+
+/* The `on:` block only -- a path filter further down would be inside a job's
+   `if:`, which is a different thing and not what this guards. */
+const triggerBlock = tests.slice(tests.indexOf('\non:'), tests.indexOf('\npermissions:'));
+
+test('the required workflow has no path filter', () => {
+  assert.doesNotMatch(triggerBlock, /paths-ignore:/,
+    'a required check with paths-ignore leaves a PR pending forever instead of failing it');
+  assert.doesNotMatch(triggerBlock, /^\s+paths:/m,
+    'same trap in the other direction: a `paths:` allowlist skips the check on everything it does not name');
+});
+
+test('the required workflow runs on pull requests into main', () => {
+  assert.match(triggerBlock, /pull_request:/, 'nothing gates a PR if the workflow does not run on one');
+  assert.match(triggerBlock, /branches: \[main\]/);
+});
+
+/* Change a name here only together with the branch protection rule in GitHub,
+   and expect this test to fail first. That is the point of it: the failure is
+   the reminder that the two are a pair. */
+const REQUIRED = [
+  'node 24',
+  'smoke (390×844)',
+  'evals',
+  'service worker behind redirects',
+  'checks that need history',
+];
+
+test('every job branch protection requires still exists under that exact name', () => {
+  for (const name of REQUIRED) {
+    assert.ok(tests.includes(`name: ${name}`),
+      `no job named "${name}". GitHub requires checks by name, so renaming one leaves branch protection waiting on a check that will never report — and the branch is unprotected while everything looks green.`);
+  }
+});
+
+test('the workflow declares no more required-looking jobs than are pinned here', () => {
+  /* A new job is not a problem; a new job nobody added to branch protection,
+     and nobody noticed was unprotected, is. This fails on the addition so the
+     decision gets made deliberately. */
+  const names = [...tests.matchAll(/^    name: (.+)$/gm)].map(m => m[1].trim());
+  assert.deepEqual(names.sort(), [...REQUIRED].sort(),
+    'a job was added to or removed from test.yml. Update branch protection and this list together, or say why the job is not required.');
+});
+
+test('vendor-drift keeps its path filter, because it is not a required check', () => {
+  const drift = read('.github/workflows/vendor-drift.yml');
+  assert.match(drift, /paths:/,
+    'vendor-drift is scheduled and label-conditional; its filter is correct and the rule above does not apply to it');
+});


### PR DESCRIPTION
Changes the rule, and removes the trap that changing it would otherwise spring.

## The trap `test.yml` has been warning about since it was written

The workflow carried `paths-ignore: notes/**` because 240 of the first 330 commits touched nothing but `notes/`, each cost six billed minutes, and none could change the answer to a question about shipped bytes. Its own comment said the filter had to go the day any check became required.

**This is that day.** A required check that does not run does not *fail* a PR — it leaves it **pending forever**, with no error to read. A notes-only PR would have hung on a job that was never going to report. The filter is gone from both triggers, and the saving it bought disappears anyway once the repo is public.

`vendor-drift.yml` **keeps** its filter. It is scheduled, label-conditional, and not required, so none of this applies to it. A rule that swept it up too is a rule someone quietly reverts.

## The second silent failure, also now pinned

GitHub requires checks **by name**. Rename `smoke (390×844)` and branch protection waits forever on a check nothing will produce, while the renamed job runs green beside it — the branch is unprotected and every signal says it is fine.

`test/ci-config.test.js` pins the five required job names, and adding or removing a job fails the suite so the branch-protection decision gets made on purpose rather than forgotten. **Five falsification arms, five caught:** filter re-added, `paths` allowlist added, job renamed, job deleted, `pull_request` trigger removed.

## REVIEW.md

Drops the paragraph saying this repo has no PRs. States two consequences with teeth:

- no path filter may be added to a required check
- **an agent may not approve its own work** — it can open the PR, answer comments and push fixes; the approval is a human's

## ⚠️ Do not enable branch protection yet

Actions is refusing to start jobs on this account over billing. Turning on required checks while that is true blocks **every** PR permanently, including the one that fixes it.

Order: get Actions running → merge this → then enable protection.

## Proof

`npm test` — 970 pass, 0 fail. Produced locally; CI cannot confirm it for the reason above.