### PR TITLE
The queue answers two questions it could not answer before

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,23 @@ is the order of operations for the parts a harness does not cover.
 which is honest rather than decorative: those checks are written down and
 nothing here can decide them.
 
+**One item at a time.** Take the top row of `notes/TICKETS.md`, finish it, hand
+it back. Not two, and not "while I am in here". A session that touches three
+items produces a diff no reviewer can judge against any one plan, which is the
+check `REVIEW.md` exists to make possible.
+
+**Done means the directory goes.** The implementation PR deletes
+`work/<slug>/` and its row in `notes/TICKETS.md`, in the same PR as the change.
+`work/` holds OPEN work; finished work is `git log` and `notes/DECISIONS.md`,
+and the artefacts stay readable forever at
+`git show <sha>:work/<slug>/plan.md`. An empty `work/` is a finished queue, not
+a broken one.
+
+The one thing this cannot be compressed into: **the artefacts must be merged
+before the implementation PR opens.** The review checks the diff against the
+plan, so a plan arriving in the same PR as the diff is a plan written to match
+it. Add and delete are never the same merge.
+
 **Review** against `REVIEW.md`, on a pull request. Every change reaches `main`
 through one — no exceptions, including a one-line fix and including a change
 that touches only `notes/`. Branch, commit, push, open the PR, and let the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,11 @@ policy constraints from the intent applied rather than restated.
 **Plan** before code, as `work/<slug>/plan.md`. Start in plan mode with the
 intent and the spec, interrogate the plan
 — what breaks, which step is riskiest, what else would work — and iterate until
-someone who had not read this file could follow it. Then commit it, either as
-the ticket's own "how" or in the commit message that lands the change. This
+someone who had not read this file could follow it. Then commit it as
+`work/<slug>/plan.md`, and merge it BEFORE the implementation PR opens — see
+the rule below, which this sentence used to contradict by also offering the
+commit message that lands the change. That option is gone: a plan arriving with
+the diff cannot be what the diff is judged against. This
 repo's dominant bug class is plan-versus-reality drift; the plan being written
 down is what makes the drift visible.
 

--- a/test/sdlc.test.js
+++ b/test/sdlc.test.js
@@ -21,8 +21,14 @@ import { readFileSync, readdirSync, existsSync } from 'node:fs';
 
 const ROOT = new URL('../', import.meta.url);
 const read = f => readFileSync(new URL(f, ROOT), 'utf8');
-const dirs = d => readdirSync(new URL(d, ROOT), { withFileTypes: true })
-  .filter(e => e.isDirectory()).map(e => e.name);
+/* Tolerant on purpose. `work/` is tracked only by `work/.gitkeep`, and a
+ * checkout that somehow lacks it must fail on an ASSERTION that names the
+ * problem, not on ENOENT thrown at module load -- which takes down every test
+ * in this file, including the ones that have nothing to do with work/. */
+const dirs = d => existsSync(new URL(d, ROOT))
+  ? readdirSync(new URL(d, ROOT), { withFileTypes: true })
+      .filter(e => e.isDirectory()).map(e => e.name)
+  : null;
 
 /* ---------- Stage 1 -> 3: the chain ---------- */
 
@@ -39,8 +45,11 @@ const items = dirs('work');
  * That is the state-of-one trap: a guard run in a single state is a guard whose
  * other states are guesses. What is checked below is the SHAPE of whatever is
  * in work/, which is the thing that can actually rot. */
-test('an empty queue is a legitimate state', () => {
-  assert.ok(Array.isArray(items), 'work/ must exist as a directory even when nothing is open');
+test('work/ survives an empty queue', () => {
+  assert.notEqual(items, null,
+    'work/ is missing from the checkout. It is tracked only by work/.gitkeep, and git does not track empty directories — so shipping the last item deletes the directory itself unless .gitkeep stays.');
+  assert.ok(existsSync(new URL('work/.gitkeep', ROOT)),
+    'work/.gitkeep is gone. The next PR that finishes the last open item removes work/ entirely, and this file then throws ENOENT at module load rather than failing one assertion.');
 });
 
 test('every work item carries the whole chain', () => {

--- a/test/sdlc.test.js
+++ b/test/sdlc.test.js
@@ -29,8 +29,18 @@ const dirs = d => readdirSync(new URL(d, ROOT), { withFileTypes: true })
 const STAGES = ['intent.md', 'spec.md', 'plan.md'];
 const items = dirs('work');
 
-test('there is at least one work item, or the chain is a directory of nothing', () => {
-  assert.ok(items.length > 0, 'work/ is empty — the artefact chain exists only as a folder');
+/* THERE IS NO ASSERTION THAT work/ IS NON-EMPTY, and there was one until the
+ * first item was about to ship. An empty queue is a finished queue. The old
+ * assertion would have gone red at the exact moment a session did the right
+ * thing -- deleted the directory of the item it had just completed -- and sent
+ * it hunting a failure that was the guard's fault, not the change's.
+ *
+ * It only ever passed because it was written while exactly one item existed.
+ * That is the state-of-one trap: a guard run in a single state is a guard whose
+ * other states are guesses. What is checked below is the SHAPE of whatever is
+ * in work/, which is the thing that can actually rot. */
+test('an empty queue is a legitimate state', () => {
+  assert.ok(Array.isArray(items), 'work/ must exist as a directory even when nothing is open');
 });
 
 test('every work item carries the whole chain', () => {

--- a/work/.gitkeep
+++ b/work/.gitkeep
@@ -1,0 +1,4 @@
+# git does not track empty directories, and `work/` must survive the last
+# item shipping: test/sdlc.test.js reads it at module load, so a missing
+# directory is not an empty queue, it is ENOENT before any test runs -- and
+# `npm test` is what Cloudflare runs before publishing.


### PR DESCRIPTION
Tested by asking a concrete question: could a fresh session be told **"grab something in work"** and get it right? Two things it could not have known.

## 1. One item at a time — written down nowhere

A session could reasonably take all three open rows. The diff that came back would be unjudgeable against any one plan, which is the check `REVIEW.md` exists to make possible.

## 2. What happens to `work/<slug>/` on completion — also nowhere, and worse

The sensible reading of "no archive" is *delete the directory*. Doing that turned the suite **red**, on an assertion I wrote that `work/` must be non-empty.

A session doing exactly the right thing would have spent its last twenty minutes debugging a guard's mistake at the moment it thought it was finished.

**That assertion only ever passed because it was written while exactly one item existed.** A guard run in a single state is a guard whose other states are guesses. An empty queue is a finished queue. What's checked now is the *shape* of whatever is in `work/` — the thing that can actually rot.

## Both new states are exercised, not assumed

| State | Result |
| --- | --- |
| directory and TICKETS row both removed | ✅ green |
| directory gone, row left behind | ✅ red, correctly caught |

The second is the one a tired session actually produces.

## Also stated

Compressing the process is the obvious next idea, and it breaks the one property worth keeping: **the artefacts must be merged before the implementation PR opens.** The review checks the diff against the plan, so a plan arriving in the same PR as the diff is a plan written to match it. Add and delete are never the same merge.

## Proof

`npm test` — 972 pass, 0 fail. One assertion replaced by a truer one.

This should also be the first PR the review workflow actually runs on — it touches no workflow files, so the validation skip that made the last one green in 12 seconds doesn't apply.