### PR TITLE
A skill for receiving a review, and a filter for not asking for one

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: address-review
+description: How to act on review findings on a pull request in this repo -- verify a finding before complying with it, fix the cause rather than the symptom named, reply with what you actually ran, resolve only what you fixed, and escalate a repeated class of mistake into the harness. Use when a reviewer (human or Claude) has left comments on a PR, when asked to address review feedback, and before resolving any review thread.
+allowed-tools: Bash(gh pr *), Bash(gh api *), Bash(npm test), Bash(npm run *), Bash(node --test*)
+---
+
+# Acting on a review
+
+`REVIEW.md` says how to GIVE a review here. This is the other direction, which
+has its own failure modes and had nothing written about it until a review found
+two real bugs and the answers to "what do I do now" were all improvised.
+
+## 1. A finding is a claim, not an instruction
+
+**Another agent's report is not proof** — `AGENTS.md` § Judgement says so about
+every other claim in this repo and it does not stop being true because the
+claim arrived as a review comment. Reproduce the failure before you fix it.
+
+Worked example, from the review that prompted this file. The finding said a
+deleted `work/` directory would throw `ENOENT` at module load and take down the
+whole test file. That was checked before it was accepted:
+
+```
+fresh checkout, work/ removed, before the fix:   0 pass, 1 fail
+after the fix, .gitkeep missing:                 6 pass, 5 fail
+after the fix, .gitkeep present, queue emptied: 11 pass, 0 fail
+```
+
+Zero-pass is the file dying before a test runs. The finding was right, the fix
+was shaped by the reproduction rather than by the comment, and the reproduction
+is what the reply could point at.
+
+**A finding you cannot reproduce is a finding you push back on**, with what you
+ran. Say so in the thread and leave it open. Complying with a wrong finding
+costs more than arguing with a right one: it puts a change in the tree that
+nothing justifies and that the next reader cannot trace to a reason.
+
+## 2. Fix the cause, not the symptom the comment names
+
+A comment names what the reviewer could see from the diff. That is often
+downstream of the real defect.
+
+The same worked example: the comment's headline was a tautological assertion
+(`Array.isArray` on a value that is an array by construction). Fixing only that
+would have left the actual bug — `work/` was tracked solely through the files
+inside it, so shipping the last item deletes the directory itself. The
+tautology was the visible end of it.
+
+## 3. Verify your fix against the state CI will see, not the one on your disk
+
+The bug above got past its own author's verification because the empty-queue
+case was tested by emptying `work/` **locally**, where the directory still
+existed. A fresh clone has no such directory.
+
+Check against `git archive` output or a clean clone whenever the change
+involves a file's existence, a directory, a checkout, or anything git tracks
+differently from a filesystem. `/browser-verify` is the equivalent rule for
+measurements; this is it for the tree.
+
+## 4. A quiet re-review is not confirmation
+
+The reviewer skips a pull request it has already commented on, and skips one
+whose workflow files the PR modifies. Both cases finish GREEN and post nothing.
+So "no new findings" can mean the fix is good, or can mean nothing ran.
+
+**Read the run log before treating silence as a pass.** A review that took
+under a minute did not review anything. The evidence your fix is right is your
+own reproduction, not the reviewer's silence.
+
+## 5. Reply with what you ran, then resolve
+
+One reply per thread, saying which of these happened:
+
+- **Addressed**, with the commit and the evidence — the numbers, not "fixed".
+- **Not a defect**, with what you ran that shows it. Leave the thread open.
+- **Real, not here** — a genuine problem outside this PR's scope. Say where it
+  goes: a `work/<slug>/intent.md`, or a row in `notes/TICKETS.md`.
+
+**Resolve only threads you actually addressed.** Never resolve to tidy the page
+— an unresolved thread you disagree with is the record of a live disagreement,
+and closing it deletes that. Resolving is a claim that the thing is done.
+
+## 6. The second time is the harness's fault, not yours
+
+This is the step everyone skips and it is the one that compounds.
+
+When a finding names a class of mistake **that is already written down** in
+`AGENTS.md` or a skill, the fix is not finished when the code is fixed. The
+harness said the right thing and failed to stop it, so the harness is what
+needs the change.
+
+Both findings on the review that prompted this file were exactly that: a guard
+that could not go red, and two answers to one question. Both are named in
+`AGENTS.md`, one of them as the worst defect in the repo's history, and both
+shipped into a pull request anyway. Fixing the two files and moving on would
+have left the next occurrence exactly as likely.
+
+Ask: could a hook have caught this? A test? A sentence in the file the mistake
+was made in? If the answer is yes, that change belongs in the same PR as the
+fix — see `/new-guard` for making it one that can actually fail.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,6 +26,25 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+    # A FILTER IS CORRECT HERE AND FORBIDDEN ON test.yml, and the difference is
+    # the whole reason to state it: this is NOT a required check. A required
+    # check that does not run leaves a PR pending forever; an advisory one that
+    # does not run simply has no opinion. `test/ci-config.test.js` enforces the
+    # other half.
+    #
+    # Only two paths, deliberately narrow. `notes/` is the queue, the research
+    # and the closed-work log; `docs/` is reference prose. Neither is shipped --
+    # `app/` is the only deployed directory -- and neither carries a rule that
+    # binds a session.
+    #
+    # ROOT *.md IS NOT EXCLUDED, and the evidence is PR #4: the review's second
+    # finding was a real contradiction introduced into AGENTS.md, in a change
+    # that looked like documentation. AGENTS.md, REVIEW.md, CLAUDE.md and
+    # README.md are rules and front door, and a mistake in them costs more than
+    # a mistake in code because everything downstream inherits it.
+    paths-ignore:
+      - 'notes/**'
+      - 'docs/**'
 
 # A review of a commit nobody is looking at any more is spend with no reader.
 # Rapid pushes collapse into one review of the latest state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,12 @@ bearing as the DENY ones: a hook that ate `grep -n update-budgets` would be
 switched off within a day, and a switched-off hook is worse than none, because
 the prose was deleted on the strength of it.
 
-Two procedures live in `.claude/skills/` rather than here, because they are
+Three procedures live in `.claude/skills/` rather than here, because they are
 sequences you follow rather than facts you need loaded at all times:
-`/browser-verify` and `/new-guard`. Both cite the sections above rather than
+`/browser-verify` and `/new-guard`, which own their subjects outright, and
+`/address-review` for acting on findings on a pull request — verify a finding
+before complying with it, and treat a repeat of a class already written down
+here as the harness failing rather than the code. Both cite the sections above rather than
 copying them. **They are Claude-specific. This file is not** — anything an
 agent must know to avoid breaking the tree belongs here, where every tool reads
 it.

--- a/test/ci-config.test.js
+++ b/test/ci-config.test.js
@@ -74,8 +74,23 @@ test('the workflow declares no more required-looking jobs than are pinned here',
     'a job was added to or removed from test.yml. Update branch protection and this list together, or say why the job is not required.');
 });
 
-test('vendor-drift keeps its path filter, because it is not a required check', () => {
-  const drift = read('.github/workflows/vendor-drift.yml');
-  assert.match(drift, /paths:/,
-    'vendor-drift is scheduled and label-conditional; its filter is correct and the rule above does not apply to it');
+/* The rule is not "no path filters". It is "no path filter on a REQUIRED
+ * check", and the two workflows below are the reason to say it that way: both
+ * carry a filter, both are correct to, and neither is required. A blanket ban
+ * would have deleted two correct filters; a blanket permission would have
+ * re-armed the trap on test.yml. */
+test('the advisory workflows keep their path filters, because neither is required', () => {
+  assert.match(read('.github/workflows/vendor-drift.yml'), /paths:/,
+    'vendor-drift is scheduled and label-conditional; its filter is correct');
+  assert.match(read('.github/workflows/claude-code-review.yml'), /paths-ignore:/,
+    'the reviewer is advisory, so skipping it on notes-only and docs-only changes costs nothing but the run');
+});
+
+test('the reviewer still runs on the files that carry the rules', () => {
+  const review = read('.github/workflows/claude-code-review.yml');
+  const ignored = review.slice(review.indexOf('paths-ignore:'), review.indexOf('concurrency:'));
+  for (const rules of ['AGENTS.md', 'REVIEW.md', 'CLAUDE.md', '*.md']) {
+    assert.ok(!ignored.includes(`'${rules}'`),
+      `${rules} is excluded from review. A contradiction introduced into the rules costs more than one in code, because everything downstream inherits it — PR #4's second finding was exactly that.`);
+  }
 });

--- a/test/one-answer.test.js
+++ b/test/one-answer.test.js
@@ -130,12 +130,26 @@ test('AGENTS.md still names the traps it no longer explains', () => {
   }
 });
 
-test('the skills declare who owns what, so the split survives being read out of order', () => {
+/* ONLY THE SKILLS THAT TOOK CONTENT OUT OF AGENTS.md HAVE TO CLAIM IT. This
+ * assertion used to apply to every skill, which was written when both of them
+ * were content transfers -- the same state-of-N trap as the empty-queue
+ * assertion two commits ago, and it produced a false failure on the first skill
+ * that was new material rather than moved material. The set is derived from
+ * OWNED rather than listed, so it stays true as skills are added. */
+const OWNERS = new Set(Object.values(OWNED)
+  .filter(f => f.startsWith(SKILL_DIR))
+  .map(f => f.split('/')[2]));
+
+test('a skill that owns moved content says so, so a future edit does not copy it back', () => {
+  for (const s of OWNERS) {
+    assert.match(raw[`${SKILL_DIR}/${s}/SKILL.md`], /owns .*? outright/,
+      `${s} owns content moved out of AGENTS.md but never says so`);
+  }
+});
+
+test('every skill declares a description, or nothing will trigger it', () => {
   for (const s of skills) {
-    const body = raw[`${SKILL_DIR}/${s}/SKILL.md`];
-    assert.match(body, /owns .* outright/,
-      `${s} does not state that it owns its subject; without that a future edit copies it back into AGENTS.md`);
-    assert.match(body, /^description:.+/m, `${s} has no description, so nothing will trigger it`);
+    assert.match(raw[`${SKILL_DIR}/${s}/SKILL.md`], /^description: .+/m, `${s} has no description`);
   }
 });
 


### PR DESCRIPTION
`REVIEW.md` says how to **give** a review. Nothing said what to do on the other end — which showed on #4, where "do I believe this finding", "what do I reply", and "may I resolve this" were all improvised, and one of them (treating a fast, quiet re-review as confirmation) was nearly wrong.

## `/address-review`

Six rules. Five are the obvious ones: verify before complying, fix the cause not the symptom, verify against the state CI sees, read the run log before treating silence as a pass, reply with numbers rather than "fixed", resolve only what you addressed.

**The sixth is the one that compounds and the one nobody does.** When a finding names a class of mistake *already written down* in the harness, the harness said the right thing and failed to stop it — so the harness needs the change, not only the code.

Both findings on #4 were exactly that: a guard that could not go red, and two answers to one question. One of them is named in this repo as its worst defect. Fixing the two files and moving on would have left the next occurrence just as likely.

## The reviewer now skips `notes/` and `docs/`

Nine minutes to review two files is real, and neither path is shipped (`app/` is the only deployed directory) nor carries a rule that binds a session.

**Root `*.md` is deliberately not excluded, and #4 is the evidence** — the second finding was a real contradiction introduced into `AGENTS.md`, in a change that looked like documentation. A mistake in the rules costs more than one in code, because everything downstream inherits it.

A filter is correct here and forbidden on `test.yml`, because this is **not a required check**. `test/ci-config.test.js` now states the rule that way rather than as "no path filters" — a blanket ban would have deleted two correct filters; a blanket permission would have re-armed the trap.

## Another of my assertions was too broad, the same way

Every skill had to declare it "owns X outright" — true of the two that were content moved out of `AGENTS.md`, meaningless for the first skill that is *new* material, which failed on arrival. Written while exactly two skills existed, both of one kind.

It now derives the owners from the `OWNED` map, so it stays true as skills are added, and still catches an owner dropping its claim.

The suite also caught something correctly on its own: `AGENTS.md` never named the new skill, so nothing routed anyone to it.

## Proof

- `npm test` — 974 pass, 0 fail
- Five falsification arms across both guards, five caught

**This PR modifies a workflow file, so the reviewer will skip itself** — expected, and documented in both workflow headers. Its own diff is yours to judge.